### PR TITLE
Render distance and infinite flat world

### DIFF
--- a/RemEngine/Assets/block.vert
+++ b/RemEngine/Assets/block.vert
@@ -2,7 +2,7 @@
 
 layout (location = 0) in vec3 position;
 layout (location = 1) in vec2 textureCoord;
-layout (location = 2) in mat4 instanceModel;
+layout (location = 2) in vec3 instancePos;
 
 uniform mat4 viewProjection;
 
@@ -10,6 +10,12 @@ out vec2 outTextureCoord;
 
 void main()
 {
-	gl_Position = viewProjection * instanceModel * vec4(position, 1.0f);
+	mat4 model;
+	model[0][0] = 1;
+	model[1][1] = 1;
+	model[2][2] = 1;
+	model[3] = vec4(instancePos, 1.0);
+
+	gl_Position = viewProjection * model * vec4(position, 1.0f);
 	outTextureCoord = textureCoord;
 }

--- a/RemEngine/RemEngine.vcxproj
+++ b/RemEngine/RemEngine.vcxproj
@@ -136,6 +136,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>opengl32.lib;glfw3.lib;assimp-vc143-mt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <StackReserveSize>4194304 </StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/RemEngine/block.h
+++ b/RemEngine/block.h
@@ -1,15 +1,12 @@
 #pragma once
+#include <boost/array.hpp>
 #include <glad/glad.h>
 #include "mesh.h"
 #include "transform.h"
 
-struct BlockInstance
-{
-	unsigned int id;
-	Transform transform;
-};
-
-BlockInstance createBlockInstance(const Transform& transform);
+#define RENDER_Y_DISTANCE 40
+#define RENDER_X_DISTANCE 100
+#define RENDER_Z_DISTANCE 100
 
 enum class UpdateType
 {
@@ -29,10 +26,13 @@ class Block
 protected:
 	BlockType type;
 	Mesh mesh;
-	std::vector<BlockInstance> blockInstances;
-	std::vector<glm::mat4> blockInstanceModels;
+
+	std::vector<glm::vec3> blockModels;
 
 	GLuint lastModelBuffer;
+
+	// Returns -1 if the block doesn't exist
+	int findBlockIndex(const glm::vec3& pos);
 public:
 	Block();
 	Block(TextureAtlas& textureAtlas, const BlockType& blockType);
@@ -40,11 +40,14 @@ public:
 	// Update index is only used if updating an element
 	void updateBlockInstanceModels(const UpdateType& updateType, int updateIndex = -1);
 
-	void resetInstances();
-	void addBlockInstance(const BlockInstance& block, bool shouldUpdateModels);
-	void updateBlockInstance(const BlockInstance& block, bool shouldUpdateModels);
-	void removeBlockInstance(unsigned int blockInstanceId, bool shouldUpdateModels);
+	void placeBlock(const glm::vec3& pos, bool shouldUpdateModels);
+	void updateBlock(const glm::vec3& pos, bool shouldUpdateModels);
+	void deleteBlock(const glm::vec3& pos, bool shouldUpdateModels);
 
+	std::vector<glm::vec3>& getBlockModels();
+
+	void removeOutsideBounds(int startX, int endX, int startZ, int endZ);
+	
 	// Draw all instances of this block
 	void drawAll(TextureAtlas& textureAtlas, glm::mat4 viewProjection);
 };

--- a/RemEngine/gameInstance.cpp
+++ b/RemEngine/gameInstance.cpp
@@ -25,7 +25,7 @@ GameInstance::GameInstance(float fieldOfView, const char* title, unsigned int wi
 	textureAtlas(TextureAtlas()),
 	lastKnownWindowSize(glm::vec2(width, height)),
 	frameTimeElapsed(0.0),
-	spectator(12.0f, 0.2f, Transform(glm::vec3(0.0f, 2.0f, -10.0f), glm::vec3(45.0f, 0.0f, 0.0f), glm::vec3(1.0f), true)),
+	spectator(12.0f, 0.2f, Transform(glm::vec3(0.0f, 22.0f, -10.0f), glm::vec3(45.0f, 0.0f, 0.0f), glm::vec3(1.0f), true)),
 	world(World())
 {
 	assert(glfwInit());

--- a/RemEngine/gameInstance.cpp
+++ b/RemEngine/gameInstance.cpp
@@ -32,8 +32,9 @@ GameInstance::GameInstance(float fieldOfView, const char* title, unsigned int wi
 
 	//  GLFW settings
 	glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
+#ifdef DEBUG
 	glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
-
+#endif
 	// Window creation
 	window = glfwCreateWindow(width, height, title, nullptr, nullptr);
 	glfwMakeContextCurrent(window);
@@ -45,8 +46,11 @@ GameInstance::GameInstance(float fieldOfView, const char* title, unsigned int wi
 
 	// OpenGL Settings
 	glEnable(GL_DEPTH_TEST);
+
+#ifdef DEBUG
 	glEnable(GL_DEBUG_OUTPUT);
 	glDebugMessageCallback(MessageCallback, 0);
+#endif
 
 	// Perform an initial clear and buffer swap
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -90,6 +94,7 @@ void GameInstance::update(double deltaTime)
 	viewProjection = projection * view;
 
 	world.update(glm::vec3(0.0f, 0.0f, 0.0f));
+	world.updateWithRenderDistance(spectator.getTransform().translationGet());
 }
 
 void GameInstance::render()

--- a/RemEngine/gameInstance.h
+++ b/RemEngine/gameInstance.h
@@ -60,4 +60,3 @@ public:
 
 	glm::mat4 getViewProjection() const;
 };
-

--- a/RemEngine/transform.cpp
+++ b/RemEngine/transform.cpp
@@ -2,6 +2,11 @@
 
 #include <glm/ext/matrix_transform.hpp>
 
+Transform::Transform()
+{
+	
+}
+
 Transform::Transform(glm::vec3 translation, glm::vec3 rotation, glm::vec3 scale, bool useGlobalTranslation)
 	: translation(translation), rotation(rotation), scale(scale), model(glm::mat4(1.0f)),
 		isUsingGlobalTranslation(useGlobalTranslation)

--- a/RemEngine/transform.h
+++ b/RemEngine/transform.h
@@ -17,6 +17,7 @@ protected:
 	 */
 	void updateModelMatrix();
 public:
+	Transform();
 	Transform(glm::vec3 translation, glm::vec3 rotation, glm::vec3 scale, bool useGlobalTranslation);
 
 	/* Translation */

--- a/RemEngine/world.cpp
+++ b/RemEngine/world.cpp
@@ -25,9 +25,6 @@ void World::updateWithRenderDistance(glm::vec3 cameraPos)
 
 	prevCameraPos = cameraPos;
 
-	printf("==========\n");
-	double startTimeTaken = glfwGetTime();
-
 	int startZ = (int) glm::floor(cameraPos.z - (RENDER_Z_DISTANCE / 2));
 	int startX = (int) glm::floor(cameraPos.x - (RENDER_X_DISTANCE / 2));
 
@@ -37,9 +34,6 @@ void World::updateWithRenderDistance(glm::vec3 cameraPos)
 	grass.removeOutsideBounds(startX, endX, startZ, endZ);
 	dirt.removeOutsideBounds(startX, endX, startZ, endZ);
 	stone.removeOutsideBounds(startX, endX, startZ, endZ);
-
-	double endTimeTaken = glfwGetTime();
-	printf("End Removing instances time: %fms\n", (endTimeTaken - startTimeTaken) * 1000);
 
 	int numBlocksAdded = 0;
 	for (int y = RENDER_Y_DISTANCE -1; y >= 0; y--)
@@ -66,8 +60,6 @@ void World::updateWithRenderDistance(glm::vec3 cameraPos)
 			}
 		}
 	}
-	endTimeTaken = glfwGetTime();
-	printf("End Adding instances time: %fms\n", (endTimeTaken - startTimeTaken) * 1000);
 
 	printf("Num Blocks Added: %d\n", numBlocksAdded);
 
@@ -85,9 +77,6 @@ void World::updateWithRenderDistance(glm::vec3 cameraPos)
 	if (!stone.getBlockModels().empty()) {
 		stone.updateBlockInstanceModels(UpdateType::AddMultipleElements);
 	}
-	
-	endTimeTaken = glfwGetTime();
-	printf("Update world time time: %fms\n", (endTimeTaken - startTimeTaken) * 1000);
 
 	prevStartX = startX;
 	prevEndX = endX;

--- a/RemEngine/world.cpp
+++ b/RemEngine/world.cpp
@@ -1,5 +1,7 @@
 #include "world.h"
 
+#include <GLFW/glfw3.h>
+
 World::World()
 {
 	
@@ -8,122 +10,100 @@ World::World()
 World::World(bool useless)
 	: textureAtlas(TextureAtlas(false)), grass(textureAtlas, BlockType::Grass),
 	dirt(textureAtlas, BlockType::Dirt), stone(textureAtlas, BlockType::Stone),
-	hasAddedNewStoneBlock(false)
+	hasAddedNewStoneBlock(false), prevCameraPos(glm::vec3(-10.0f, -10.0f, -10.0)),
+	prevStartX(0), prevEndX(0), prevStartZ(0), prevEndZ(0)
 {
-	// Fill the block grid
-	for (int y = Y_BLOCKS-1; y >= 0; y--)
-	{
-		for (int z=0; z < Z_BLOCKS; z++)
-		{
-			for (int x=0; x < X_BLOCKS; x++)
-			{
-				if (y > Y_BLOCKS / 2) {
-					blockGrid[y][z][x] = BlockType::Air;
-				}
-				else if (y == (Y_BLOCKS / 2)) {
-					blockGrid[y][z][x] = BlockType::Grass;
-				}
-				else if (y < (Y_BLOCKS /2) && y > (Y_BLOCKS / 2)-6)
-				{
-					blockGrid[y][z][x] = BlockType::Dirt;
-				}
-				else
-				{
-					blockGrid[y][z][x] = BlockType::Stone;
-				}
-			}
-		}
-	}
 
-	// Add the block instances
-	create();
 }
 
-void World::create()
+void World::updateWithRenderDistance(glm::vec3 cameraPos)
 {
-	// TODO: Only add block instances that have at least one adjacent air tile
-	for (int y = Y_BLOCKS - 1; y >= 0; y--)
+	if (glm::floor(cameraPos) == glm::floor(prevCameraPos))
 	{
-		for (int z = 0; z < Z_BLOCKS; z++)
-		{
-			for (int x = 0; x < X_BLOCKS; x++)
-			{
-				BlockType blockType = blockGrid[y][z][x];
+		return;
+	}
 
-				bool isAirBlockAdjacent = false;
-				for (int adjY = y + 1; adjY >= y - 1; adjY--)
+	prevCameraPos = cameraPos;
+
+	printf("==========\n");
+	double startTimeTaken = glfwGetTime();
+
+	int startZ = (int) glm::floor(cameraPos.z - (RENDER_Z_DISTANCE / 2));
+	int startX = (int) glm::floor(cameraPos.x - (RENDER_X_DISTANCE / 2));
+
+	int endZ = (int) glm::floor(cameraPos.z + (RENDER_Z_DISTANCE / 2));
+	int endX = (int) glm::floor(cameraPos.x + (RENDER_X_DISTANCE / 2));
+
+	grass.removeOutsideBounds(startX, endX, startZ, endZ);
+	dirt.removeOutsideBounds(startX, endX, startZ, endZ);
+	stone.removeOutsideBounds(startX, endX, startZ, endZ);
+
+	double endTimeTaken = glfwGetTime();
+	printf("End Removing instances time: %fms\n", (endTimeTaken - startTimeTaken) * 1000);
+
+	int numBlocksAdded = 0;
+	for (int y = RENDER_Y_DISTANCE -1; y >= 0; y--)
+	{
+		for (int z = startZ; z <= endZ; z++)
+		{
+			for (int x = startX; x <= endX; x++)
+			{
+				bool shouldAddBlockInstance = false;
+
+				if (x > prevEndX || z > prevEndZ || x < prevStartX || z < prevStartZ)
 				{
-					for (int adjZ = z - 1; adjZ <= z + 1; adjZ++)
-					{
-						for (int adjX = x - 1; adjX <= x + 1; adjX++)
-						{
-							if (adjY > 0 && adjY < Y_BLOCKS-1 &&
-								adjZ > 0 && adjZ < Z_BLOCKS-1 &&
-								adjX > 0 && adjX < X_BLOCKS-1)
-							{
-								if (blockGrid[adjY][adjZ][adjX] == BlockType::Air)
-								{
-									isAirBlockAdjacent = true;
-									break;
-								}
-							}
-							else if (adjX == 0 || adjZ == 0 || y == 0 || adjX == X_BLOCKS-1 || adjZ == Z_BLOCKS-1)
-							{
-								isAirBlockAdjacent = true;
-							}
-						}
-					}
+					shouldAddBlockInstance = true;
 				}
 
-				if (blockType != BlockType::Air && isAirBlockAdjacent) {
-					Transform transform = Transform(glm::vec3(x, y, z), glm::vec3(0.0f), glm::vec3(1.0f), true);
-					BlockInstance instance = createBlockInstance(transform);
-
-					if (blockType == BlockType::Grass)
+				if (shouldAddBlockInstance)
+				{
+					if (y == (40 - 1) / 2)
 					{
-						grass.addBlockInstance(instance, false);
-					}
-					else if (blockType == BlockType::Dirt)
-					{
-						dirt.addBlockInstance(instance, false);
-					}
-					else if (blockType == BlockType::Stone)
-					{
-						stone.addBlockInstance(instance, false);
+						numBlocksAdded++;
+						grass.placeBlock(glm::vec3(x, y, z), false);
 					}
 				}
 			}
 		}
 	}
+	endTimeTaken = glfwGetTime();
+	printf("End Adding instances time: %fms\n", (endTimeTaken - startTimeTaken) * 1000);
 
-	grass.updateBlockInstanceModels(UpdateType::AddMultipleElements);
-	dirt.updateBlockInstanceModels(UpdateType::AddMultipleElements);
-	stone.updateBlockInstanceModels(UpdateType::AddMultipleElements);
+	printf("Num Blocks Added: %d\n", numBlocksAdded);
+
+	/*
+	 * Update the Matrix Models
+	 */
+	if (!grass.getBlockModels().empty()) {
+		grass.updateBlockInstanceModels(UpdateType::AddMultipleElements);
+	}
+
+	if (!dirt.getBlockModels().empty()) {
+		dirt.updateBlockInstanceModels(UpdateType::AddMultipleElements);
+	}
+
+	if (!stone.getBlockModels().empty()) {
+		stone.updateBlockInstanceModels(UpdateType::AddMultipleElements);
+	}
+	
+	endTimeTaken = glfwGetTime();
+	printf("Update world time time: %fms\n", (endTimeTaken - startTimeTaken) * 1000);
+
+	prevStartX = startX;
+	prevEndX = endX;
+	prevStartZ = startZ;
+	prevEndZ = endZ;
 }
 
 void World::update(glm::vec3 cameraPos)
 {
 	if (!hasAddedNewStoneBlock)
 	{
-		BlockInstance stoneBlock = createBlockInstance(
-			Transform(glm::vec3(0, 50, 0), glm::vec3(0.0f), glm::vec3(1.0f), true)
-		);
-
-		stone.addBlockInstance(
-			stoneBlock,
+		stone.placeBlock(
+			glm::vec3(0, 50, 0),
 			true
 		);
 
-		dirt.addBlockInstance(
-			createBlockInstance(
-				Transform(glm::vec3(1, 50, 0), glm::vec3(0.0f), glm::vec3(1.0f), true)
-			),
-			true
-		);
-
-		stoneBlock.transform.translationSet(glm::vec3(0.0f, 51.0f, 0.0f));
-		stone.updateBlockInstance(stoneBlock, true);
-		//stone.removeBlockInstance(stoneBlock.id, true);
 		hasAddedNewStoneBlock = true;
 	}
 }

--- a/RemEngine/world.h
+++ b/RemEngine/world.h
@@ -2,30 +2,30 @@
 #include "block.h"
 #include <boost/multi_array.hpp>
 
-#define Y_BLOCKS 40
-#define Z_BLOCKS 192
-#define X_BLOCKS 192
-
-#define RENDER_X_DISTANCE 192
-#define RENDER_Z_DISTANCE 192
+#define RENDER_Y_DISTANCE 40
+#define RENDER_X_DISTANCE 100
+#define RENDER_Z_DISTANCE 100
 
 class World
 {
 protected:
-	boost::multi_array<BlockType, 3> blockGrid { boost::extents[Y_BLOCKS][Z_BLOCKS][X_BLOCKS] };
-
 	TextureAtlas textureAtlas;
 
 	Block grass;
 	Block dirt;
 	Block stone;
 
+	int prevStartX, prevEndX;
+	int prevStartZ, prevEndZ;
+
+	glm::vec3 prevCameraPos;
+
 	bool hasAddedNewStoneBlock;
 public:
 	World();
 	World(bool useless);
 
-	void create();
+	void updateWithRenderDistance(glm::vec3 cameraPos);
 
 	// Update in line with the player position
 	void update(glm::vec3 cameraPos);


### PR DESCRIPTION
The world now renders around the player, there are no longer _block instances._, instead a std::vector with just the position is stored, which significantly reduces the burden in the update loop. Additionally, the blocks rendered are only changed when the player moves to a new block. The world at the moment is simply a flat world akin to a Minecraft 'superflat' world, which is infinite.