### PR TITLE
Chunk system

### DIFF
--- a/RemEngine/Chunk.cpp
+++ b/RemEngine/Chunk.cpp
@@ -1,0 +1,54 @@
+#include "Chunk.h"
+
+Chunk::Chunk(TextureAtlas& textureAtlas, glm::vec3 position)
+	: textureAtlas(textureAtlas), grass(textureAtlas, BlockType::Grass),
+	dirt(textureAtlas, BlockType::Dirt), stone(textureAtlas, BlockType::Stone),
+	position(position)
+{
+	for (int y = position.y; y >= position.y-CHUNK_SIZE.y; y--)
+	{
+		for (int z=position.z; z < position.z + CHUNK_SIZE.z; z++)
+		{
+			for (int x=position.x; x < position.x + CHUNK_SIZE.x; x++)
+			{
+				glm::vec3 actualPosition = glm::vec3(x, y, z);
+
+				if (y == 0) {
+					grass.placeBlock(actualPosition, false);
+				} else if (y < 0 && y > -5)
+				{
+					dirt.placeBlock(actualPosition, false);
+				}
+				else if (y <= -5)
+				{
+					stone.placeBlock(actualPosition, false);
+				}
+
+			}
+		}
+	}
+
+	grass.updateBlockInstanceModels(UpdateType::AddMultipleElements);
+	dirt.updateBlockInstanceModels(UpdateType::AddMultipleElements);
+	stone.updateBlockInstanceModels(UpdateType::AddMultipleElements);
+}
+
+void Chunk::draw(glm::mat4 viewProjection)
+{
+	grass.drawAll(textureAtlas, viewProjection);
+	dirt.drawAll(textureAtlas, viewProjection);
+	stone.drawAll(textureAtlas, viewProjection);
+}
+
+void Chunk::release()
+{
+	grass.release();
+	dirt.release();
+	stone.release();
+}
+
+void Chunk::getChunkBounds(glm::vec3& position, glm::vec3& size)
+{
+	position = this->position;
+	size = CHUNK_SIZE;
+}

--- a/RemEngine/Chunk.h
+++ b/RemEngine/Chunk.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <vector>
+
+#include "block.h"
+
+#define CHUNK_SIZE glm::vec3(16, 16, 16)
+
+class Chunk
+{
+protected:
+	TextureAtlas& textureAtlas;
+	Block grass;
+	Block dirt;
+	Block stone;
+	glm::vec3 position;
+public:
+	Chunk(TextureAtlas& textureAtlas, glm::vec3 position);
+
+	void draw(glm::mat4 viewProjection);
+	void release();
+
+	void getChunkBounds(glm::vec3& position, glm::vec3& size);
+};

--- a/RemEngine/Chunk.h
+++ b/RemEngine/Chunk.h
@@ -8,7 +8,7 @@
 class Chunk
 {
 protected:
-	TextureAtlas& textureAtlas;
+	TextureAtlas textureAtlas;
 	Block grass;
 	Block dirt;
 	Block stone;

--- a/RemEngine/RemEngine.vcxproj
+++ b/RemEngine/RemEngine.vcxproj
@@ -142,9 +142,11 @@
   <ItemGroup>
     <ClCompile Include="..\ExternalLibs\glad\src\glad.c" />
     <ClCompile Include="block.cpp" />
+    <ClCompile Include="Chunk.cpp" />
     <ClCompile Include="gameInstance.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="mesh.cpp" />
+    <ClCompile Include="renderer.cpp" />
     <ClCompile Include="world.cpp" />
     <ClCompile Include="shader.cpp" />
     <ClCompile Include="spectator.cpp" />
@@ -153,8 +155,10 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="block.h" />
+    <ClInclude Include="Chunk.h" />
     <ClInclude Include="gameInstance.h" />
     <ClInclude Include="mesh.h" />
+    <ClInclude Include="renderer.h" />
     <ClInclude Include="shader.h" />
     <ClInclude Include="spectator.h" />
     <ClInclude Include="textureAtlas.h" />

--- a/RemEngine/RemEngine.vcxproj.filters
+++ b/RemEngine/RemEngine.vcxproj.filters
@@ -45,6 +45,12 @@
     <ClCompile Include="world.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="renderer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Chunk.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="shader.h">
@@ -72,6 +78,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="world.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="renderer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Chunk.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/RemEngine/block.cpp
+++ b/RemEngine/block.cpp
@@ -157,24 +157,20 @@ Block::Block(TextureAtlas& textureAtlas, const BlockType& blockType)
 
 	ShaderProgram blockShader = createShaderProgram("Assets/block.vert", "Assets/block.frag");
 
-	GLuint cubeVao;
 	glGenVertexArrays(1, &cubeVao);
 	glBindVertexArray(cubeVao);
 
-	GLuint cubeVbo;
 	glGenBuffers(1, &cubeVbo);
 	glBindBuffer(GL_ARRAY_BUFFER, cubeVbo);
 	glBufferData(GL_ARRAY_BUFFER, blockVerts.size() * sizeof(GLfloat), blockVerts.data(), GL_STATIC_DRAW);
-
-	GLuint cubeEbo;
+	
 	glGenBuffers(1, &cubeEbo);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, cubeEbo);
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, blockIndices.size() * sizeof(GLint), blockIndices.data(), GL_STATIC_DRAW);
 
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(GLfloat), (void*)0);
 	glEnableVertexAttribArray(0);
-
-	GLuint textureVbo;
+	
 	glGenBuffers(1, &textureVbo);
 	glBindBuffer(GL_ARRAY_BUFFER, textureVbo);
 	glBufferData(GL_ARRAY_BUFFER, textureCoordinates.size() * sizeof(GLfloat), textureCoordinates.data(), GL_STATIC_DRAW);
@@ -375,18 +371,35 @@ std::vector<glm::vec3>& Block::getBlockModels()
 
 void Block::removeOutsideBounds(int startX, int endX, int startZ, int endZ)
 {
-	int numRemoved = 0;
-	for (int i=0; i < blockModels.size(); i++)
+	for (int i = 0; i < blockModels.size(); i++)
 	{
 		glm::vec3& pos = blockModels.at(i);
 
-		if (pos.z < startZ || pos.z > endZ
-			|| pos.x < startX || pos.x > endX)
+		if ((pos.x > endX || pos.x < startX) || (pos.z > endZ || pos.z < startZ))
 		{
 			blockModels.erase(std::begin(blockModels) + i);
-			numRemoved++;
 		}
 	}
+}
 
-	printf("Num Blocks Removed: %d\n", numRemoved);
+bool Block::isBlockAtPos(glm::vec3 pos)
+{
+	if (findBlockIndex(pos) == -1)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+void Block::release()
+{
+	glDeleteBuffers(1, &lastModelBuffer);
+	glDeleteBuffers(1, &mesh.vao);
+	glDeleteBuffers(1, &cubeVbo);
+	glDeleteBuffers(1, &cubeEbo);
+	glDeleteBuffers(1, &textureVbo);
+
+	glDeleteProgram(mesh.shaderProgram);
+	blockModels.erase(blockModels.begin(), blockModels.end());
 }

--- a/RemEngine/block.h
+++ b/RemEngine/block.h
@@ -27,22 +27,30 @@ protected:
 	BlockType type;
 	Mesh mesh;
 
+	GLuint cubeVao;
+	GLuint cubeVbo;
+	GLuint cubeEbo;
+	GLuint textureVbo;
+
 	std::vector<glm::vec3> blockModels;
 
 	GLuint lastModelBuffer;
 
 	// Returns -1 if the block doesn't exist
 	int findBlockIndex(const glm::vec3& pos);
+	int binarySearch(const glm::vec3& pos, int low, int high);
 public:
 	Block();
 	Block(TextureAtlas& textureAtlas, const BlockType& blockType);
 
 	// Update index is only used if updating an element
+
 	void updateBlockInstanceModels(const UpdateType& updateType, int updateIndex = -1);
 
 	void placeBlock(const glm::vec3& pos, bool shouldUpdateModels);
 	void updateBlock(const glm::vec3& pos, bool shouldUpdateModels);
 	void deleteBlock(const glm::vec3& pos, bool shouldUpdateModels);
+	bool isBlockAtPos(glm::vec3 pos);
 
 	std::vector<glm::vec3>& getBlockModels();
 
@@ -50,4 +58,6 @@ public:
 	
 	// Draw all instances of this block
 	void drawAll(TextureAtlas& textureAtlas, glm::mat4 viewProjection);
+
+	void release();
 };

--- a/RemEngine/gameInstance.cpp
+++ b/RemEngine/gameInstance.cpp
@@ -25,7 +25,7 @@ GameInstance::GameInstance(float fieldOfView, const char* title, unsigned int wi
 	textureAtlas(TextureAtlas()),
 	lastKnownWindowSize(glm::vec2(width, height)),
 	frameTimeElapsed(0.0),
-	spectator(12.0f, 0.2f, Transform(glm::vec3(0.0f, 22.0f, -10.0f), glm::vec3(45.0f, 0.0f, 0.0f), glm::vec3(1.0f), true)),
+	spectator(12.0f, 0.2f, Transform(glm::vec3(0.0f, 1.0f, 0.0f), glm::vec3(45.0f, 0.0f, 0.0f), glm::vec3(1.0f), true)),
 	world(World())
 {
 	assert(glfwInit());
@@ -71,7 +71,7 @@ GameInstance::GameInstance(float fieldOfView, const char* title, unsigned int wi
 	// Setup the textureAtlas
 	textureAtlas = TextureAtlas(false);
 
-	world = World(false);
+	world = World(textureAtlas);
 }
 
 void GameInstance::update(double deltaTime)
@@ -92,8 +92,7 @@ void GameInstance::update(double deltaTime)
 
 	viewProjection = projection * view;
 
-	world.update(glm::vec3(0.0f, 0.0f, 0.0f));
-	world.updateWithRenderDistance(spectator.getTransform().translationGet());
+	world.update(spectator.getTransform().translationGet());
 }
 
 void GameInstance::render()

--- a/RemEngine/mesh.cpp
+++ b/RemEngine/mesh.cpp
@@ -3,6 +3,7 @@
 #include <glm/gtc/type_ptr.hpp>
 
 #include "world.h"
+#include <cstddef>
 
 Mesh createColouredCube(glm::vec3 colour)
 {
@@ -249,4 +250,48 @@ Mesh createTexturedBlock(TextureAtlas& textureAtlas, const BlockType& blockType)
 	glUniform1i(textureSamplerLoc, 0);
 
 	return block;
+}
+
+AMesh createMesh(std::vector<AVertex> vertices, std::vector<GLuint> indices, std::vector<ATexture> textures)
+{
+	AMesh mesh{};
+	mesh.vertices = vertices;
+	mesh.indices = indices;
+	mesh.textures = textures;
+
+	glGenVertexArrays(1, &mesh.vao);
+	glGenBuffers(1, &mesh.vbo);
+	glGenBuffers(1, &mesh.ebo);
+
+	glBindVertexArray(mesh.vao);
+	glBindBuffer(GL_ARRAY_BUFFER, mesh.vbo);
+	glBufferData(GL_ARRAY_BUFFER, mesh.vertices.size() * sizeof(AVertex), &mesh.vertices[0], GL_STATIC_DRAW);
+
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.ebo);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh.indices.size() * sizeof(GLuint), &mesh.indices[0], GL_STATIC_DRAW);
+
+	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(AVertex), (void*)0);
+
+	glEnableVertexAttribArray(1);
+	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(AVertex), (void*) offsetof(AVertex, normal));
+
+	glEnableVertexAttribArray(2);
+	glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(AVertex), (void*) offsetof(AVertex, textureCoord));
+
+	glBindVertexArray(0);
+
+	return mesh;
+}
+
+void drawMesh(const AMesh& mesh)
+{
+	GLuint diffuseNum = 1;
+	GLuint specularNum = 1;
+
+	for (GLuint i = 0; i < mesh.textures.size(); i++)
+	{
+		glActiveTexture(GL_TEXTURE0 + i);
+		std::string number;
+	}
 }

--- a/RemEngine/mesh.h
+++ b/RemEngine/mesh.h
@@ -6,6 +6,8 @@
 #include "shader.h"
 #include "textureAtlas.h"
 
+// Old Mesh stuff
+
 struct Mesh
 {
 	GLuint vao;
@@ -16,3 +18,32 @@ struct Mesh
 
 Mesh createColouredCube(glm::vec3 colour);
 Mesh createTexturedBlock(TextureAtlas& textureAtlas, const BlockType& blockType);
+
+// New Mesh stuff
+
+struct AVertex
+{
+	glm::vec3 position;
+	glm::vec3 normal;
+	glm::vec3 textureCoord;
+};
+
+struct ATexture
+{
+	GLuint id;
+	std::string type;
+};
+
+// TODO: This will be used in a future Model class, that will use Assimp.
+struct AMesh
+{
+	std::vector<AVertex> vertices;
+	std::vector<GLuint> indices;
+	std::vector<ATexture> textures;
+	GLuint vao;
+	GLuint vbo;
+	GLuint ebo;
+};
+
+AMesh createMesh(std::vector<AVertex> vertices, std::vector<GLuint> indices, std::vector<ATexture> textures);
+void drawMesh(const AMesh& mesh);

--- a/RemEngine/renderer.cpp
+++ b/RemEngine/renderer.cpp
@@ -1,0 +1,19 @@
+#include "renderer.h"
+
+Renderer::Renderer(TextureAtlas& textureAtlas)
+	: textureAtlas(textureAtlas)
+{
+	GLsizei blockPositionsSize = 0;
+	// TODO: Determine the size of block positions...
+
+	glGenBuffers(1, &blockPositionsBuffer);
+	glBindBuffer(GL_ARRAY_BUFFER, blockPositionsBuffer);
+	glBufferStorage(GL_ARRAY_BUFFER, blockPositionsSize, nullptr, GL_DYNAMIC_STORAGE_BIT);
+
+	// Sub all the data into the buffer...
+}
+
+void Renderer::Draw(glm::mat4 viewProjection)
+{
+
+}

--- a/RemEngine/renderer.h
+++ b/RemEngine/renderer.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "block.h"
+#include "textureAtlas.h"
+
+/*
+ * An instance of this class should only be created after an OpenGL context has been created
+ */
+class Renderer
+{
+protected:
+	TextureAtlas textureAtlas;
+	GLuint blockPositionsBuffer;
+public:
+	Renderer(TextureAtlas& textureAtlas);
+	void Draw(glm::mat4 viewProjection);
+};

--- a/RemEngine/world.cpp
+++ b/RemEngine/world.cpp
@@ -2,6 +2,21 @@
 
 #include <GLFW/glfw3.h>
 
+int findClosestNumber(int val, int multiple)
+{
+	int quotient = val / multiple;
+
+	int option1 = multiple * quotient;
+	int option2 = multiple * (quotient + 1);
+
+	if (abs(val - option1) < abs(val - option2))
+	{
+		return option1;
+	}
+
+	return option2;
+}
+
 World::World()
 {
 	
@@ -12,19 +27,78 @@ World::World(TextureAtlas& textureAtlas)
 	prevCameraPos(glm::vec3(.0f, 1, 0.0)),
 	chunks(std::vector<Chunk>())
 {
-	chunks.emplace_back(Chunk(textureAtlas, glm::vec3(0, 0, 0)));
-	chunks.emplace_back(Chunk(textureAtlas, glm::vec3(16, 0, 0)));
-	chunks.emplace_back(Chunk(textureAtlas, glm::vec3(0, 0, 16)));
-	chunks.emplace_back(Chunk(textureAtlas, glm::vec3(16, 0, 16)));
+	
 }
 
 void World::update(glm::vec3 cameraPos)
 {
-	// TODO: Get the 12x12 chunk positions
-	// TODO: Delete chunks that aren't one of the positions
-	// TODO: Add the new chunks to be loaded in
+	glm::vec3 chunkPositions[11][11];
 
+	glm::vec3 middleChunkPos = glm::vec3(
+		findClosestNumber(cameraPos.x, 16),
+		findClosestNumber(cameraPos.y, 16),
+		findClosestNumber(cameraPos.z, 16)
+	);
 
+	glm::vec3 firstChunkPos = glm::vec3(
+		middleChunkPos.x - (5 * 16),
+		middleChunkPos.y,
+		middleChunkPos.z - (5 * 16)
+	);
+
+	// Find each chunk position
+	glm::vec3 *chunksNotLoaded[11][11];
+	for (int z=0; z < 11; z++)
+	{
+		for (int x=0; x < 11; x++)
+		{
+			glm::vec3 chunkPos = glm::vec3(
+				findClosestNumber(firstChunkPos.x + x * 16, 16),
+				0,
+				findClosestNumber(firstChunkPos.z + z * 16, 16)
+			);
+
+			chunkPositions[z][x] = chunkPos;
+			chunksNotLoaded[z][x] = &chunkPositions[z][x];
+		}
+	}
+	
+	for (int i=0; i < chunks.size(); i++)
+	{
+		glm::vec3 chunkPos;
+		glm::vec3 chunkSize;
+
+		chunks.at(i).getChunkBounds(chunkPos, chunkSize);
+
+		bool isChunkOutOfBounds = true;
+		for (int z = 0; z < 11; z++)
+		{
+			for (int x = 0; x < 11; x++)
+			{
+				if (chunkPositions[z][x] == chunkPos)
+				{
+					isChunkOutOfBounds = false;
+					chunksNotLoaded[z][x] = nullptr;
+				}
+			}
+		}
+
+		if (isChunkOutOfBounds) {
+			chunks.at(i).release();
+			chunks.erase(chunks.begin() + i);
+		}
+	}
+
+	for (int z = 0; z < 11; z++)
+	{
+		for (int x = 0; x < 11; x++)
+		{
+			if (chunksNotLoaded[z][x] != nullptr) {
+				glm::vec3 notLoadedPos = *chunksNotLoaded[z][x];
+				chunks.emplace_back(Chunk(textureAtlas, notLoadedPos));
+			}
+		}
+	}
 }
 
 void World::draw(TextureAtlas& textureAtlas, glm::mat4 viewProjection)

--- a/RemEngine/world.cpp
+++ b/RemEngine/world.cpp
@@ -7,99 +7,30 @@ World::World()
 	
 }
 
-World::World(bool useless)
-	: textureAtlas(TextureAtlas(false)), grass(textureAtlas, BlockType::Grass),
-	dirt(textureAtlas, BlockType::Dirt), stone(textureAtlas, BlockType::Stone),
-	hasAddedNewStoneBlock(false), prevCameraPos(glm::vec3(-10.0f, -10.0f, -10.0)),
-	prevStartX(0), prevEndX(0), prevStartZ(0), prevEndZ(0)
+World::World(TextureAtlas& textureAtlas)
+	: textureAtlas(textureAtlas),
+	prevCameraPos(glm::vec3(.0f, 1, 0.0)),
+	chunks(std::vector<Chunk>())
 {
-
-}
-
-void World::updateWithRenderDistance(glm::vec3 cameraPos)
-{
-	if (glm::floor(cameraPos) == glm::floor(prevCameraPos))
-	{
-		return;
-	}
-
-	prevCameraPos = cameraPos;
-
-	int startZ = (int) glm::floor(cameraPos.z - (RENDER_Z_DISTANCE / 2));
-	int startX = (int) glm::floor(cameraPos.x - (RENDER_X_DISTANCE / 2));
-
-	int endZ = (int) glm::floor(cameraPos.z + (RENDER_Z_DISTANCE / 2));
-	int endX = (int) glm::floor(cameraPos.x + (RENDER_X_DISTANCE / 2));
-
-	grass.removeOutsideBounds(startX, endX, startZ, endZ);
-	dirt.removeOutsideBounds(startX, endX, startZ, endZ);
-	stone.removeOutsideBounds(startX, endX, startZ, endZ);
-
-	int numBlocksAdded = 0;
-	for (int y = RENDER_Y_DISTANCE -1; y >= 0; y--)
-	{
-		for (int z = startZ; z <= endZ; z++)
-		{
-			for (int x = startX; x <= endX; x++)
-			{
-				bool shouldAddBlockInstance = false;
-
-				if (x > prevEndX || z > prevEndZ || x < prevStartX || z < prevStartZ)
-				{
-					shouldAddBlockInstance = true;
-				}
-
-				if (shouldAddBlockInstance)
-				{
-					if (y == (40 - 1) / 2)
-					{
-						numBlocksAdded++;
-						grass.placeBlock(glm::vec3(x, y, z), false);
-					}
-				}
-			}
-		}
-	}
-
-	printf("Num Blocks Added: %d\n", numBlocksAdded);
-
-	/*
-	 * Update the Matrix Models
-	 */
-	if (!grass.getBlockModels().empty()) {
-		grass.updateBlockInstanceModels(UpdateType::AddMultipleElements);
-	}
-
-	if (!dirt.getBlockModels().empty()) {
-		dirt.updateBlockInstanceModels(UpdateType::AddMultipleElements);
-	}
-
-	if (!stone.getBlockModels().empty()) {
-		stone.updateBlockInstanceModels(UpdateType::AddMultipleElements);
-	}
-
-	prevStartX = startX;
-	prevEndX = endX;
-	prevStartZ = startZ;
-	prevEndZ = endZ;
+	chunks.emplace_back(Chunk(textureAtlas, glm::vec3(0, 0, 0)));
+	chunks.emplace_back(Chunk(textureAtlas, glm::vec3(16, 0, 0)));
+	chunks.emplace_back(Chunk(textureAtlas, glm::vec3(0, 0, 16)));
+	chunks.emplace_back(Chunk(textureAtlas, glm::vec3(16, 0, 16)));
 }
 
 void World::update(glm::vec3 cameraPos)
 {
-	if (!hasAddedNewStoneBlock)
-	{
-		stone.placeBlock(
-			glm::vec3(0, 50, 0),
-			true
-		);
+	// TODO: Get the 12x12 chunk positions
+	// TODO: Delete chunks that aren't one of the positions
+	// TODO: Add the new chunks to be loaded in
 
-		hasAddedNewStoneBlock = true;
-	}
+
 }
 
 void World::draw(TextureAtlas& textureAtlas, glm::mat4 viewProjection)
 {
-	grass.drawAll(textureAtlas, viewProjection);
-	dirt.drawAll(textureAtlas, viewProjection);
-	stone.drawAll(textureAtlas, viewProjection);
+	for (Chunk& chunk : chunks)
+	{
+		chunk.draw(viewProjection);
+	}
 }

--- a/RemEngine/world.h
+++ b/RemEngine/world.h
@@ -10,6 +10,8 @@ protected:
 	TextureAtlas textureAtlas;
 	glm::vec3 prevCameraPos;
 	std::vector<Chunk> chunks;
+
+	glm::vec3 chunkPositions[11][11];
 public:
 	World();
 	World(TextureAtlas& textureAtlas);

--- a/RemEngine/world.h
+++ b/RemEngine/world.h
@@ -2,30 +2,17 @@
 #include "block.h"
 #include <boost/multi_array.hpp>
 
-#define RENDER_Y_DISTANCE 40
-#define RENDER_X_DISTANCE 100
-#define RENDER_Z_DISTANCE 100
+#include "Chunk.h"
 
 class World
 {
 protected:
 	TextureAtlas textureAtlas;
-
-	Block grass;
-	Block dirt;
-	Block stone;
-
-	int prevStartX, prevEndX;
-	int prevStartZ, prevEndZ;
-
 	glm::vec3 prevCameraPos;
-
-	bool hasAddedNewStoneBlock;
+	std::vector<Chunk> chunks;
 public:
 	World();
-	World(bool useless);
-
-	void updateWithRenderDistance(glm::vec3 cameraPos);
+	World(TextureAtlas& textureAtlas);
 
 	// Update in line with the player position
 	void update(glm::vec3 cameraPos);


### PR DESCRIPTION
This is the start of the chunk system. The performance is significantly worse, as this is the unoptimised version. The chunk system was used to remove the problems with the old world loading system. The old system had jaggedy blocks left over when moving around and also stuttered a lot when deleting blocks due to the size of the container holding all the blocks.

This system can be optimised, for example not every block needs to be added. Currently every block in a chunk regardless of whether or not it can be seen by the player is added to the containers. 